### PR TITLE
Prefer default description to the title header

### DIFF
--- a/lib/compilers.js
+++ b/lib/compilers.js
@@ -427,7 +427,7 @@ function root(node) {
     var defaults = self.defaultManConfiguration;
     var name = config.name || defaults.name || '';
     var section = config.section || defaults.section || '';
-    var description = config.description || defaults.section || '';
+    var description = config.description || defaults.description || config.title || '';
     var links = {};
     var headings = {};
     var value;

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -52,7 +52,7 @@ function transformer(ast, file) {
             man.section = match[2];
             man.description = match[3];
         } else {
-            man.description = value;
+            man.title = value;
         }
     } else if (file.filename) {
         value = file.filename.split('.');


### PR DESCRIPTION
`mdast-man` [parses] markdown headers to extract name, section, and description, but if the pattern does not apply, it uses the title as a description anyway even if there has been given one in plugin settings.

I am trying to use `mdast-man` on readmes from npm packages I have no control over, and this leaves me with meaningless descriptions even if the whole `package.json` is at my disposal, and I can easily get the description from it.

This patch makes `mdast-man` use the default description in these cases.

[parses]: https://github.com/wooorm/mdast-man/blob/073f9612c87e0565296ecc63ffdab67be5988093/lib/transformer.js#L48-56