### PR TITLE
Convert top-level section names to all-caps

### DIFF
--- a/lib/compilers.js
+++ b/lib/compilers.js
@@ -217,8 +217,14 @@ function paragraph(node) {
  */
 function heading(node) {
     var name = node.depth === 2 ? 'SH' : 'SS';
+    var value = this.all(node).join('');
 
-    return macro(name, quote(this.all(node).join('')));
+    // Convert top-level section names to ALL-CAPS.
+    if (name === 'SH') {
+        value = value.toUpperCase();
+    }
+
+    return macro(name, quote(value));
 }
 
 var MAILTO = 'mailto:';

--- a/test/fixtures/missing-titles.2/output.roff
+++ b/test/fixtures/missing-titles.2/output.roff
@@ -1,13 +1,13 @@
 .TH "MISSING-TITLES" "2" "July 2015" "" ""
 .SH "NAME"
 \fBmissing-titles\fR
-.SH "Level two"
+.SH "LEVEL TWO"
 .P
 Some text.
 .SS "Level three"
 .P
 Some text.
-.SH "Level two"
+.SH "LEVEL TWO"
 .P
 Some text.
 .SS "Level three"


### PR DESCRIPTION
Conventional top-level sections (listed in `man-pages(7)`) are all in uppercase (e.g. `NAME`, `DESCRIPTION`), but Markdown section are usually spelled in mixed case (e.g. `License`). This can lead to ugly man pages with some sections following one convention and others following the other.

This patch converts all top-level section names to uppercase automatically.